### PR TITLE
various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ This role installs Portainer using Docker container
 - Configure Portainer settings [Jinja2 template]
 - Configure registry [Jinja2 template]
 
+## Requirements
+
+- `curl`
+
 ## Role Vars
 name | description | default |
 -----|-------------|---------|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ admin_password: password
 
 # Endpoints
 endpoints:
-  - {name: local, url: "unix:///var/run/docker.sock"}
+  - {name: local, url: ""}
   - {name: remote1, url: "tcp://1.2.3.4:2375"}
   - {name: remote2, url: "tcp://5.6.7.8:2375"}
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ configure_registry: false
 remove_persistent_data: false
 remove_existing_container: false
 persistent_data_path: /opt/portainer:/data
+container_labels: {}
+container_restart_policy: always
 auth_method: 1
 
 # Portainer version

--- a/tasks/admin.yml
+++ b/tasks/admin.yml
@@ -1,0 +1,8 @@
+- name: Configure admin user password
+  uri:
+    url: "{{ portainer_endpoint }}/users/admin/init"
+    method: POST
+    return_content: yes
+    body_format: json
+    body: '{ "Username":"{{ admin_user }}", "Password":"{{ admin_password }}"}'
+    status_code: 200, 409

--- a/tasks/admin.yml
+++ b/tasks/admin.yml
@@ -1,3 +1,4 @@
+---
 - name: Configure admin user password
   uri:
     url: "{{ portainer_endpoint }}/users/admin/init"

--- a/tasks/clean-up.yml
+++ b/tasks/clean-up.yml
@@ -1,0 +1,14 @@
+---
+- name: Remove existing container
+  docker_container:
+    name: portainer
+    state: absent
+    purge_networks: yes
+    force_kill: yes
+  when: remove_existing_container
+
+- name: Remove persistent data
+  file:
+    state: absent
+    path: "{{ persistent_data_path }}"
+  when: remove_persistent_data

--- a/tasks/endpoints.yml
+++ b/tasks/endpoints.yml
@@ -27,7 +27,7 @@
 
 - name: Define Endpoints
   shell: |
-    curl --silent --show-error -o /dev/null -w "%{http_code}" {{ portainer_endpoint }}/endpoints \
+    curl --silent --show-error -o - {{ portainer_endpoint }}/endpoints \
       -H "Authorization: Bearer {{ (auth_token.content|from_json).jwt }}" \
       -F "Name={{ item.name }}" \
       -F "URL={{ item.url }}" \
@@ -38,7 +38,16 @@
     - "{{ endpoints | list }}"
   when: item.name not in portainer_known_endpoints
   register: response
-  #failed_when: response.stdout.find("200") != -1
 
-#- name: "TESTING, TEST"
-#  debug: msg="{{ response }}"
+#- name: "Debug response"
+#  debug:
+#    msg: "Endpoint {{ item.item.name }}, Response: {{ item.stdout| default('{}')|from_json }}"
+#  with_items:
+#    - "{{ response.results }}"
+
+- name: Verifying calls
+  fail:
+    msg: "Could not add endpoint: {{ item.item.name }} (Error: ...)"
+  failed_when: item.skipped is defined or ((item.stdout is defined) and (item.stdout|from_json).err is not defined)
+  with_items:
+    - "{{ response.results }}"

--- a/tasks/endpoints.yml
+++ b/tasks/endpoints.yml
@@ -36,7 +36,7 @@
     warn: False
   with_items:
     - "{{ endpoints | list }}"
-  when: item not in portainer_known_endpoints
+  when: item.name not in portainer_known_endpoints
   register: response
   #failed_when: response.stdout.find("200") != -1
 

--- a/tasks/endpoints.yml
+++ b/tasks/endpoints.yml
@@ -1,0 +1,44 @@
+---
+- name: Generate authentication token
+  uri:
+    url: "{{ portainer_endpoint }}/auth"
+    method: POST
+    return_content: yes
+    body_format: json
+    body: '{"Username": "{{ admin_user }}", "Password": "{{ admin_password }}"}'
+  register: auth_token
+  when: admin_user and admin_password is defined
+
+- name: Get Endpoints
+  uri:
+    url: "{{ portainer_endpoint }}/endpoints"
+    method: GET
+    return_content: yes
+    headers:
+      Authorization: Bearer {{ (auth_token.content|from_json).jwt }}
+  register: portainer_known_endpoints_raw
+
+- name: Save endpoints as fact 
+  set_fact:
+    portainer_known_endpoints: "{{ portainer_known_endpoints_raw.json | map(attribute='Name') | list }}"
+
+- name: "EHLO endpoints"
+  debug: msg="{{ portainer_known_endpoints }}"
+
+- name: Define Endpoints
+  shell: |
+    curl --silent --show-error -o /dev/null -w "%{http_code}" {{ portainer_endpoint }}/endpoints \
+      -H "Authorization: Bearer {{ (auth_token.content|from_json).jwt }}" \
+      -F "Name={{ item.name }}" \
+      -F "URL={{ item.url }}" \
+      -F "EndpointType=1"
+  args:
+    warn: False
+  with_items:
+    - "{{ endpoints | list }}"
+  when: item not in portainer_known_endpoints
+  register: response
+  #failed_when: response.stdout.find("200") != -1
+
+- name: "TESTING, TEST"
+  debug: msg="{{ response }}"

--- a/tasks/endpoints.yml
+++ b/tasks/endpoints.yml
@@ -22,7 +22,7 @@
   set_fact:
     portainer_known_endpoints: "{{ portainer_known_endpoints_raw.json | map(attribute='Name') | list }}"
 
-- name: "EHLO endpoints"
+- name: "Show known endpoints"
   debug: msg="{{ portainer_known_endpoints }}"
 
 - name: Define Endpoints
@@ -40,5 +40,5 @@
   register: response
   #failed_when: response.stdout.find("200") != -1
 
-- name: "TESTING, TEST"
-  debug: msg="{{ response }}"
+#- name: "TESTING, TEST"
+#  debug: msg="{{ response }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,19 @@
+---
+- name: "Deploy Portainer to {{ inventory_hostname }}"
+  docker_container:
+    name: portainer
+    image: "portainer/portainer:{{ version }}"
+    state: started
+    detach: true
+    recreate: yes
+    restart_policy: always
+    published_ports:
+      - "{{ host_port }}:9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - "{{ persistent_data_path }}"
+
+- name: Wait for container
+  wait_for:
+    port: "{{ host_port }}"
+    host: "{{ inventory_hostname }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,10 +3,11 @@
   docker_container:
     name: portainer
     image: "portainer/portainer:{{ version }}"
+    labels: "{{ container_labels | default(omit) }}"
     state: started
     detach: true
     recreate: yes
-    restart_policy: always
+    restart_policy: "{{ container_restart_policy }}"
     published_ports:
       - "{{ host_port }}:9000"
     volumes:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
     return_content: yes
     body_format: json
     body: { "Username":"{{ admin_user }}", "Password":"{{ admin_password }}"}
+    status_code: 200, 409
   when: admin_user and admin_password is defined
 
 - name: Generate authentication token

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,23 +11,8 @@
 - include: admin.yml
   when: admin_user and admin_password is defined
 
-- name: Define Endpoints
-  shell: |
-    curl --silent --show-error -o /dev/null -w "%{http_code}" {{ portainer_endpoint }}/endpoints \
-      -H "Authorization: Bearer {{ (auth_token.content|from_json).jwt }}" \
-      -F "Name={{ item.name }}" \
-      -F "URL={{ item.url }}" \
-      -F "EndpointType=1"
-  args:
-    warn: False
-  with_items:
-    - "{{ endpoints | list }}"
+- include: endpoints.yml
   when: endpoints is defined
-  register: response
-  #failed_when: response.stdout.find("200") != -1
-
-- name: "TESTING, TEST"
-  debug: msg="{{ response }}"
 
 - name: Configure Portainer settings
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,14 +59,20 @@
   when: admin_user and admin_password is defined
 
 - name: Define Endpoints
-  uri:
-    url: "{{ portainer_endpoint }}/endpoints"
-    method: POST
-    return_content: yes
-    headers:
-      Authorization: "{{ (auth_token.content|from_json).jwt }}"
-    body: {"Name":"{{ item.name }}", "URL":"{{ item.url }}"}
-    body_format: json
+  command:
+  args:
+    argv:
+      - curl
+      - -f
+      - "{{ portainer_endpoint }}/endpoints"
+      - -H
+      - "Authorization: Bearer {{ (auth_token.content|from_json).jwt }}"
+      - -F
+      - "Name={{ item.name }}"
+      - -F
+      - "URL={{ item.url }}"
+      - -F
+      - "EndpointType=1"
   with_items:
     - "{{ endpoints | list }}"
   when: endpoints is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
     method: POST
     return_content: yes
     body_format: json
-    body: { "Username":"{{ admin_user }}", "Password":"{{ admin_password }}"}
+    body: '{ "Username":"{{ admin_user }}", "Password":"{{ admin_password }}"}'
     status_code: 200, 409
   when: admin_user and admin_password is defined
 
@@ -54,34 +54,27 @@
     method: POST
     return_content: yes
     body_format: json
-    body: {"Username": "{{ admin_user }}", "Password": "{{ admin_password }}"}
+    body: '{"Username": "{{ admin_user }}", "Password": "{{ admin_password }}"}'
   register: auth_token
   when: admin_user and admin_password is defined
 
 - name: Define Endpoints
-  command:
+  shell: |
+    curl --silent --show-error -o /dev/null -w "%{http_code}" {{ portainer_endpoint }}/endpoints \
+      -H "Authorization: Bearer {{ (auth_token.content|from_json).jwt }}" \
+      -F "Name={{ item.name }}" \
+      -F "URL={{ item.url }}" \
+      -F "EndpointType=1"
   args:
-    argv:
-      - curl
-      - -o
-      - -
-      - -w
-      - "\n%{http_code}\n"
-      - "{{ portainer_endpoint }}/endpoints"
-      - -H
-      - "Authorization: Bearer {{ (auth_token.content|from_json).jwt }}"
-      - -F
-      - "Name={{ item.name }}"
-      - -F
-      - "URL={{ item.url }}"
-      - -F
-      - "EndpointType=1"
-    warn: false
+    warn: False
   with_items:
     - "{{ endpoints | list }}"
   when: endpoints is defined
-  register: result
-  failed_when: result.stdout.find("200") != -1
+  register: response
+  #failed_when: response.stdout.find("200") != -1
+
+- name: "TESTING, TEST"
+  debug: msg="{{ response }}"
 
 - name: Configure Portainer settings
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,24 +6,7 @@
 
 - include: clean-up.yml
 
-- name: "Deploy Portainer to {{ inventory_hostname }}"
-  docker_container:
-    name: portainer
-    image: "portainer/portainer:{{ version }}"
-    state: started
-    detach: true
-    recreate: yes
-    restart_policy: always
-    published_ports:
-      - "{{ host_port }}:9000"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - "{{ persistent_data_path }}"
-
-- name: Wait for container
-  wait_for:
-    port: "{{ host_port }}"
-    host: "{{ inventory_hostname }}"
+- include: install.yml
 
 - include: admin.yml
   when: admin_user and admin_password is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,7 +63,10 @@
   args:
     argv:
       - curl
-      - -f
+      - -o
+      - -
+      - -w
+      - "\n%{http_code}\n"
       - "{{ portainer_endpoint }}/endpoints"
       - -H
       - "Authorization: Bearer {{ (auth_token.content|from_json).jwt }}"
@@ -73,9 +76,12 @@
       - "URL={{ item.url }}"
       - -F
       - "EndpointType=1"
+    warn: false
   with_items:
     - "{{ endpoints | list }}"
   when: endpoints is defined
+  register: result
+  failed_when: result.stdout.find("200") != -1
 
 - name: Configure Portainer settings
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,10 @@
 ---
-
 - name: Install Docker-py
   pip:
     name: docker-py
     state: present
 
-- name: Remove existing container
-  docker_container:
-    name: portainer
-    state: absent
-    purge_networks: yes
-    force_kill: yes
-  when: remove_existing_container
-
-- name: Remove persistent data
-  file:
-    state: absent
-    path: "{{ persistent_data_path }}"
-  when: remove_persistent_data
+- include: clean-up.yml
 
 - name: "Deploy Portainer to {{ inventory_hostname }}"
   docker_container:
@@ -38,24 +25,7 @@
     port: "{{ host_port }}"
     host: "{{ inventory_hostname }}"
 
-- name: Configure admin user password
-  uri:
-    url: "{{ portainer_endpoint }}/users/admin/init"
-    method: POST
-    return_content: yes
-    body_format: json
-    body: '{ "Username":"{{ admin_user }}", "Password":"{{ admin_password }}"}'
-    status_code: 200, 409
-  when: admin_user and admin_password is defined
-
-- name: Generate authentication token
-  uri:
-    url: "{{ portainer_endpoint }}/auth"
-    method: POST
-    return_content: yes
-    body_format: json
-    body: '{"Username": "{{ admin_user }}", "Password": "{{ admin_password }}"}'
-  register: auth_token
+- include: admin.yml
   when: admin_user and admin_password is defined
 
 - name: Define Endpoints
@@ -87,13 +57,5 @@
     body: "{{ lookup('template','settings.json.j2') }}"
   when: configure_settings
 
-- name: Configure Registry
-  uri:
-    url: "{{ portainer_endpoint }}/registries"
-    method: POST
-    return_content: yes
-    headers:
-      Authorization: "{{ (auth_token.content|from_json).jwt }}"
-    body_format: json
-    body: "{{ lookup('template','registry.json.j2') }}"
+- include: registry.yml
   when: configure_registry

--- a/tasks/registry.yml
+++ b/tasks/registry.yml
@@ -1,0 +1,10 @@
+---
+- name: Configure Registry
+  uri:
+    url: "{{ portainer_endpoint }}/registries"
+    method: POST
+    return_content: yes
+    headers:
+      Authorization: "{{ (auth_token.content|from_json).jwt }}"
+    body_format: json
+    body: "{{ lookup('template','registry.json.j2') }}"


### PR DESCRIPTION
## Fix: allow ansible to continue when admin is already added

 - status code 409 means "conflict", so we ignore this and let the run continue
 - according to API spec: https://app.swaggerhub.com/apis/deviantony/Portainer/1.20.0/#/users/UserAdminInit

## Fix: define endpoints

* add curl to requirements
* fix "define endpoints"
* get endpoints from portainer (and save as fact)
* skip adding an endpoint if one with the same name already exists

## Doc fixes

 * for local endpoint, URL can be empty

## Refactor

 * move most/all steps to individual task files 
 * added/left some debug code to see responses

## Feature

 * add options for labels and restart policy

see https://app.swaggerhub.com/apis/deviantony/Portainer/1.20.0/#/endpoints/EndpointCreate
(command with curl because of
ansible/ansible#38172)